### PR TITLE
storing sessions in app/sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 /app/bootstrap.php.cache
 /app/cache/*
 /app/logs/*
+/app/sessions/*
 !app/cache/.gitkeep
 !app/logs/.gitkeep
+!app/sessions/.gitkeep
 /app/phpunit.xml
 /build/
 /vendor/

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -30,6 +30,7 @@ disk: 2048
 mounts:
     "/app/cache": "shared:files/cache"
     "/app/logs": "shared:files/logs"
+    "/app/sessions": "shared:files/sessions"
 
 # The hooks that will be performed when the package is deployed.
 hooks:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -27,8 +27,9 @@ framework:
     trusted_hosts:   ~
     trusted_proxies: ~
     session:
-        # handler_id set to null will use default session handler from php.ini
-        handler_id:  ~
+        # http://symfony.com/doc/current/reference/configuration/framework.html#handler-id
+        handler_id:  session.handler.native_file
+        save_path:   "%kernel.root_dir%/../app/sessions/%kernel.environment%"
     fragments:       ~
     http_method_override: true
 

--- a/app/config/parameters_platform.php
+++ b/app/config/parameters_platform.php
@@ -19,6 +19,3 @@ foreach ($relationships['database'] as $endpoint) {
     $container->setParameter('database_password', $endpoint['password']);
     $container->setParameter('database_path', '');
 }
-
-# Store session into /tmp.
-ini_set('session.save_path', '/tmp/sessions');


### PR DESCRIPTION
Hi guys!

Disclaimer: I haven't tested this :). I sent a ticket to platform.sh asking why sessions are stored in /tmp, which is not guaranteed to have permanent persistence. @pjcdawkins answered back that this is probably not the right spot for sessions.

This sets up the `session.handler.native_file` by default and configured sessions to be stored in `app/sessions`, which is then mounted as a shared file. It should work (and there is a PR to the Symfony SE right now to make this the default configuration - except that it's `var/cache` in Symfony 3) - but it should be tested real quick on platform of course :).

Thanks!