### PR TITLE
Fix SQLite usage in the Demo application

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -13,8 +13,6 @@ build:
 # The left-hand side is the name of the relationship as it will be exposed
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
-relationships:
-    database: "mysql:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:
@@ -39,7 +37,8 @@ hooks:
     deploy: |
       set -e
       if [ $PLATFORM_ENVIRONMENT = "master" ] && [ ! -f app/database/.platform.installed ]; then
-        cp -R app/data app/database
+        cp -R app/data/* app/database
         touch app/database/.platform.installed
       fi
       app/console --env=prod cache:clear
+

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -9,10 +9,6 @@ type: php:7.0
 build:
   flavor: symfony
 
-# The relationships of the application with services or other applications.
-# The left-hand side is the name of the relationship as it will be exposed
-# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
-# side is in the form `<service name>:<endpoint name>`.
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -30,10 +30,16 @@ disk: 2048
 mounts:
     "/app/cache": "shared:files/cache"
     "/app/logs": "shared:files/logs"
+    "/app/database": "shared:files/database"
 
 # The hooks that will be performed when the package is deployed.
 hooks:
     build: |
       rm web/app_dev.php
     deploy: |
+      set -e
+      if [ $PLATFORM_ENVIRONMENT = "master" ] && [ ! -f app/database/.platform.installed ]; then
+        cp -R app/data app/database
+        touch app/database/.platform.installed
+      fi
       app/console --env=prod cache:clear

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,3 +1,3 @@
-mysql:
-    type: mysql:5.5
-    disk: 2048
+#mysql:
+#    type: mysql:5.5
+#    disk: 2048

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,3 +1,0 @@
-#mysql:
-#    type: mysql:5.5
-#    disk: 2048

--- a/app/config/parameters_platform.php
+++ b/app/config/parameters_platform.php
@@ -4,21 +4,9 @@ if (!$relationships) {
     return;
 }
 
-$relationships = json_decode(base64_decode($relationships), true);
-
-foreach ($relationships['database'] as $endpoint) {
-    if (empty($endpoint['query']['is_master'])) {
-      continue;
-    }
-
-    $container->setParameter('database_driver', 'pdo_' . $endpoint['scheme']);
-    $container->setParameter('database_host', $endpoint['host']);
-    $container->setParameter('database_port', $endpoint['port']);
-    $container->setParameter('database_name', $endpoint['path']);
-    $container->setParameter('database_user', $endpoint['username']);
-    $container->setParameter('database_password', $endpoint['password']);
-    $container->setParameter('database_path', '');
-}
+// Use an SQLite database set in a mounted directory, on Platform.sh only.
+$container->setParameter('database_driver', 'pdo_sqlite');
+$container->setParameter('database_path', '../app/database/blog.sqlite');
 
 # Store session into /tmp.
 ini_set('session.save_path', '/tmp/sessions');


### PR DESCRIPTION
This PR applies the lock-file fix to the Symfony demo application.  Since the demo app uses an SQLite database, we do not need the MySQL container at all.  However, we do need to "install" it by copying the database one time to a dedicated writeable location.

Note: This PR does not render the demo branch fully functional, as there is another issue with one of the dependent libraries trying to write to the vendor directory by default.  That will be addressed separately.